### PR TITLE
Linux build fixes

### DIFF
--- a/Source/WTF/wtf/glib/GRefPtr.h
+++ b/Source/WTF/wtf/glib/GRefPtr.h
@@ -34,8 +34,11 @@ extern "C" {
     GDBusNodeInfo* g_dbus_node_info_ref(GDBusNodeInfo*);
     void g_dbus_node_info_unref(GDBusNodeInfo*);
 };
+
+#if !PLATFORM(QT)
 extern "C" void g_object_unref(gpointer);
 extern "C" gpointer g_object_ref_sink(gpointer);
+#endif
 
 namespace WTF {
 

--- a/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/PlatformDisplayGStreamer.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "PlatformDisplay.h"
 
+#if USE(GSTREAMER_GL)
+
 #include "GLContext.h"
 #include "GStreamerCommon.h"
 #define GST_USE_UNSTABLE_API
@@ -34,8 +36,6 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
 #define GST_CAT_DEFAULT webkit_media_player_debug
 
 namespace WebCore {
-
-#if USE(GSTREAMER_GL)
 
 GstGLDisplay* PlatformDisplay::gstGLDisplay() const
 {
@@ -74,6 +74,6 @@ GstGLContext* PlatformDisplay::gstGLContext() const
     return m_gstGLContext.get();
 }
 
-#endif // USE(GSTREAMER_GL)
-
 } // namespace WebCore
+
+#endif // USE(GSTREAMER_GL)


### PR DESCRIPTION
Right now qtwebkit doesn't build under some linux platforms:

* Including `gst/gl/gl.h` causes issues because gstreamer-gl installs its libs in a weird place. And we're not using gstreamer-gl anyway, so move the guard to ignore it
* GRefPtr conflicts