### PR TITLE
`WebCore::PathQt::platformPath()`: don't return a temporary object

### DIFF
--- a/Source/WebCore/platform/graphics/qt/PathQt.cpp
+++ b/Source/WebCore/platform/graphics/qt/PathQt.cpp
@@ -110,7 +110,7 @@ Ref<PathImpl> PathQt::copy() const
     return create(m_path);
 }
 
-QPainterPath PathQt::platformPath() const
+PlatformPathPtr PathQt::platformPath() const
 {
     return m_path;
 }

--- a/Source/WebCore/platform/graphics/qt/PathQt.h
+++ b/Source/WebCore/platform/graphics/qt/PathQt.h
@@ -52,7 +52,7 @@ public:
     PathQt& operator=(const PathQt&);
     PathQt& operator=(PathQt&& other);
 
-    QPainterPath platformPath() const;
+    PlatformPathPtr platformPath() const;
 
     void addPath(const PathQt&, const AffineTransform&);
 
@@ -67,8 +67,6 @@ public:
 
 private:
     Ref<PathImpl> copy() const final;
-
-    QPainterPath ensurePlatformPath() { return platformPath(); }
 
     void add(PathMoveTo) final;
 


### PR DESCRIPTION
`WebCore::Path::platformPath()` expects to be able to return the return value of `WebCore::PlatformPathImpl::platformPath()` as a `PlatformPathPtr` without creating a dangling reference. However, `WebCore::PathQt::platformPath()` is defined as returning a temporary `QPainterPath` object, which does become a dangling reference when returned by reference, leading to segfaults at runtime.

This PR changes the return type of `WebCore::PathQt::platformPath()` to `PlatformPathPtr` (paralleling the definition of `WebCore::PathCG::platformPath()`), so as to avoid creating a temporary `QPainterPath` object, thereby avoiding the creation of a dangling reference when returning from `WebCore::Path::platformPath()`.

Fixes: https://github.com/movableink/webkit/issues/37