### PR TITLE
fix build with `ENABLE_VIDEO=OFF`

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "GPUDevice.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
 #include "EventNames.h"
 #include "GPUBindGroup.h"

--- a/Source/WebCore/html/HTMLMarqueeElement.cpp
+++ b/Source/WebCore/html/HTMLMarqueeElement.cpp
@@ -26,6 +26,7 @@
 #include "Attribute.h"
 #include "CSSPropertyNames.h"
 #include "CSSValueKeywords.h"
+#include "ContainerNodeInlines.h"
 #include "ElementInlines.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -29,6 +29,7 @@
 #include "CachedImage.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "ContainerNodeInlines.h"
 #include "DocumentLoader.h"
 #include "EventListener.h"
 #include "EventNames.h"

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -24,6 +24,7 @@
 #include "ImageInputType.h"
 
 #include "CachedImage.h"
+#include "ContainerNodeInlines.h"
 #include "DOMFormData.h"
 #include "ElementInlines.h"
 #include "HTMLFormElement.h"

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "NumberInputType.h"
 
+#include "ContainerNodeInlines.h"
 #include "Decimal.h"
 #include "ElementInlines.h"
 #include "HTMLInputElement.h"

--- a/Source/WebCore/html/shadow/ProgressShadowElement.cpp
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "ProgressShadowElement.h"
 
+#include "ContainerNodeInlines.h"
 #include "HTMLNames.h"
 #include "HTMLProgressElement.h"
 #include "RenderProgress.h"

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -30,6 +30,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSToLengthConversionData.h"
 #include "CommonAtomStrings.h"
+#include "ContainerNodeInlines.h"
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "EventNames.h"

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3168,6 +3168,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserA
     return { };
 }
 
+#if ENABLE(VIDEO)
 static Inspector::Protocol::DOM::VideoProjectionMetadataKind videoProjectionMetadataKind(VideoProjectionMetadataKind kind)
 {
     switch (kind) {
@@ -3189,6 +3190,7 @@ static Inspector::Protocol::DOM::VideoProjectionMetadataKind videoProjectionMeta
     ASSERT_NOT_REACHED();
     return Inspector::Protocol::DOM::VideoProjectionMetadataKind::Unknown;
 }
+#endif
 
 Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> InspectorDOMAgent::getMediaStats(Inspector::Protocol::DOM::NodeId nodeId)
 {

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -29,6 +29,7 @@
 #include "CachedResourceRequest.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "ContainerNodeInlines.h"
 #include "CookieJar.h"
 #include "CrossOriginAccessControl.h"
 #include "Document.h"

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -41,6 +41,7 @@
 #include "Quirks.h"
 #include "SecurityOrigin.h"
 #include <wtf/text/MakeString.h>
+#include <JavaScriptCore/ConsoleTypes.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -28,6 +28,7 @@
 
 #include "AccessibilityObject.h"
 #include "BorderShape.h"
+#include "ContainerNodeInlines.h"
 #include "Document.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementInlines.h"

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3023,9 +3023,11 @@ void Page::setShouldSuppressHDR(bool shouldSuppressHDR)
         return;
 
     m_shouldSuppressHDR = shouldSuppressHDR;
+#if ENABLE(VIDEO)
     forEachDocument([](auto& document) {
         document.shouldSuppressHDRDidChange();
     });
+#endif
 }
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/page/PageGroupLoadDeferrer.cpp
+++ b/Source/WebCore/page/PageGroupLoadDeferrer.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "PageGroupLoadDeferrer.h"
 
+#include "ActiveDOMObject.h"
 #include "Document.h"
 #include "DocumentParser.h"
 #include "LocalFrame.h"

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -73,9 +73,11 @@ protected:
     bool m_mockMediaSourceEnabled { false };
 };
 
+#if ENABLE(VIDEO)
 inline void MediaStrategy::nativeImageFromVideoFrame(const VideoFrame&, CompletionHandler<void(std::optional<RefPtr<NativeImage>>&&)>&& completionHandler)
 {
     completionHandler(std::nullopt);
 }
+#endif
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -25,6 +25,7 @@
 #include "RenderListItem.h"
 
 #include "CSSFontSelector.h"
+#include "ContainerNodeInlines.h"
 #include "ElementInlines.h"
 #include "ElementTraversal.h"
 #include "HTMLNames.h"

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -29,6 +29,7 @@
 
 #include "AXObjectCache.h"
 #include "BoundaryPointInlines.h"
+#include "ContainerNodeInlines.h"
 #include "DocumentInlines.h"
 #include "EditingInlines.h"
 #include "Editor.h"

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -120,7 +120,11 @@ static bool shouldRepaintOnSizeChange(RenderReplaced& renderer)
 {
     if (is<RenderHTMLCanvas>(renderer))
         return true;
-    if (auto* renderImage = dynamicDowncast<RenderImage>(renderer); renderImage && !is<RenderMedia>(*renderImage) && !renderImage->isShowingMissingOrImageError())
+    if (auto* renderImage = dynamicDowncast<RenderImage>(renderer); renderImage
+#if ENABLE(VIDEO)
+            && !is<RenderMedia>(*renderImage)
+#endif
+            && !renderImage->isShowingMissingOrImageError())
         return true;
     return false;
 }

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -29,6 +29,7 @@
 #include "ColorLuminance.h"
 #include "ColorSerialization.h"
 #include "ColorWellPart.h"
+#include "ContainerNodeInlines.h"
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
 #include "FileList.h"

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -28,6 +28,7 @@
 
 #include "ClipRect.h"
 #include "ColorSerialization.h"
+#include "ContainerNodeInlines.h"
 #include "Document.h"
 #include "ElementInlines.h"
 #include "FrameSelection.h"


### PR DESCRIPTION
Disabling video support reveals some missing includes and other minor oversights. This PR fixes them.