### PR TITLE
Add asset notifications

### DIFF
--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -474,6 +474,12 @@ void DocumentThreadableLoader::notifyFinished(CachedResource& resource, const Ne
     ASSERT(m_client);
     ASSERT_UNUSED(resource, &resource == m_resource);
 
+#if PLATFORM(QT)
+    LocalFrame* localFrame = document().frame();
+    if (localFrame)
+        localFrame->loader().client().dispatchDidFinishResourceLoad(resource);    
+#endif    
+
     if (m_resource->errorOccurred())
         didFail(m_resource->resourceLoaderIdentifier(), m_resource->resourceError());
     else
@@ -595,6 +601,13 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
 
         auto cachedResource = m_document->protectedCachedResourceLoader()->requestRawResource(WTFMove(newRequest));
         m_resource = cachedResource.value_or(nullptr);
+
+#if PLATFORM(QT)
+        LocalFrame* localFrame = document().frame();
+        if (localFrame && m_resource.get())
+            localFrame->loader().client().dispatchDidStartResourceLoad(*m_resource.get());
+#endif
+
         if (CachedResourceHandle resource = m_resource)
             resource->addClient(*this);
         else

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -469,6 +469,12 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
 {
     LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " notifyFinished - hasPendingLoadEvent " << m_hasPendingLoadEvent);
 
+#if PLATFORM(QT)
+    LocalFrame* localFrame = element().document().frame();
+    if (localFrame)
+        localFrame->loader().client().dispatchDidFinishResourceLoad(resource);
+#endif
+
     ASSERT(m_failedLoadURL.isEmpty());
     ASSERT_UNUSED(resource, &resource == m_image.get());
 
@@ -690,6 +696,12 @@ void ImageLoader::dispatchPendingBeforeLoadEvent()
         return;
     if (!element().document().hasLivingRenderTree())
         return;
+#if PLATFORM(QT)
+    LocalFrame* localFrame = element().document().frame();
+    if (localFrame)
+        localFrame->loader().client().dispatchDidStartResourceLoad(*m_image.get());
+#endif
+
     m_hasPendingBeforeLoadEvent = false;
     if (!element().isConnected())
         return;

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -41,6 +41,10 @@
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
+#if PLATFORM(QT)
+#include "CachedResource.h"
+#endif
+
 #if ENABLE(APPLICATION_MANIFEST)
 #include "ApplicationManifest.h"
 #endif
@@ -160,6 +164,10 @@ public:
     virtual void dispatchDidFinishLoading(DocumentLoader*, IsMainResourceLoad, ResourceLoaderIdentifier) = 0;
     virtual void dispatchDidFailLoading(DocumentLoader*, IsMainResourceLoad, ResourceLoaderIdentifier, const ResourceError&) = 0;
     virtual bool dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int length) = 0;
+#if PLATFORM(QT)
+    virtual void dispatchDidStartResourceLoad(const CachedResource&) { }
+    virtual void dispatchDidFinishResourceLoad(const CachedResource&) { }
+#endif
 
     virtual void dispatchDidDispatchOnloadEvents() = 0;
     virtual void dispatchDidReceiveServerRedirectForProvisionalLoad() = 0;

--- a/Source/WebKitLegacy/PlatformQt.cmake
+++ b/Source/WebKitLegacy/PlatformQt.cmake
@@ -215,6 +215,7 @@ set(QtWebKit_PUBLIC_FRAMEWORK_HEADERS
     qt/Api/qwebhistory.h
     qt/Api/qwebhistoryinterface.h
     qt/Api/qwebkitglobal.h
+    qt/Api/qwebresourcetypes.h
     qt/Api/qwebkitplatformplugin.h
     qt/Api/qwebpluginfactory.h
     qt/Api/qwebscriptworld.h
@@ -238,6 +239,7 @@ ecm_generate_headers(
         QWebHistoryInterface
         QWebKitPlatformPlugin,QWebHapticFeedbackPlayer,QWebFullScreenVideoHandler,QWebNotificationData,QWebNotificationPresenter,QWebSelectData,QWebSelectMethod,QWebSpellChecker,QWebTouchModifier
         QWebPluginFactory
+        QWebResourceTypes
         QWebSecurityOrigin
         QWebSettings
     COMMON_HEADER

--- a/Source/WebKitLegacy/qt/Api/qwebresourcetypes.h
+++ b/Source/WebKitLegacy/qt/Api/qwebresourcetypes.h
@@ -1,0 +1,44 @@
+/*
+    Copyright (C) 2025 Michael Nutt <michael@nuttnet.net>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public License
+    along with this library; see the file COPYING.LIB.  If not, write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA 02110-1301, USA.
+*/
+
+#ifndef QWEBRESOURCETYPES_H
+#define QWEBRESOURCETYPES_H
+
+#include <QtWebKit/qwebkitglobal.h>
+#include <QtCore/QString>
+#include <QtCore/QUrl>
+
+// These types are duplicated from WebCore to provide a clean public API
+// They have the same layout and field names so Qt signals/slots can pass them directly
+
+struct QWEBKIT_EXPORT QtResourceTimingInfo {
+    qint64 domainLookupMs = -1;
+    qint64 connectMs = -1;
+    qint64 sslMs = -1;
+    qint64 requestMs = -1;
+    qint64 responseMs = -1;
+    qint64 totalMs = 0;
+};
+
+struct QWEBKIT_EXPORT QtResourceRequestInfo {
+    QString initiatorType;
+    QString resourceType;
+};
+
+#endif // QWEBRESOURCETYPES_H

--- a/Source/WebKitLegacy/qt/WebCoreSupport/FrameLoaderClientQt.h
+++ b/Source/WebKitLegacy/qt/WebCoreSupport/FrameLoaderClientQt.h
@@ -30,13 +30,16 @@
 #ifndef FrameLoaderClientQt_h
 #define FrameLoaderClientQt_h
 
+#include <WebCore/CachedResource.h>
 #include <WebCore/FormState.h>
 #include <WebCore/LocalFrameLoaderClient.h>
+#include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/ProcessSwapDisposition.h>
 #include <WebCore/ResourceResponse.h>
 #include <WebCore/ResourceError.h>
 
 #include <QObject>
+#include "qwebresourcetypes.h"
 #include <QUrl>
 #include <wtf/URL.h>
 
@@ -68,6 +71,8 @@ class FrameLoaderClientQt final : public QObject, public LocalFrameLoaderClient 
 Q_SIGNALS:
     void titleChanged(const QString& title);
     void unsupportedContent(QNetworkReply*);
+    void resourceLoadStarted(const QUrl& url, const QtResourceRequestInfo& requestInfo, bool fromCache);
+    void resourceLoadFinished(const QUrl& url, qint64 size, const QtResourceTimingInfo& timing, bool success);
 
 public:
     FrameLoaderClientQt(WebCore::FrameLoader&);
@@ -97,6 +102,8 @@ public:
     void dispatchDidFinishLoading(WebCore::DocumentLoader*, WebCore::IsMainResourceLoad, WebCore::ResourceLoaderIdentifier) override;
     void dispatchDidFailLoading(WebCore::DocumentLoader*, WebCore::IsMainResourceLoad, WebCore::ResourceLoaderIdentifier, const WebCore::ResourceError&) override;
     bool dispatchDidLoadResourceFromMemoryCache(WebCore::DocumentLoader*, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, int) override;
+    void dispatchDidStartResourceLoad(const WebCore::CachedResource&) override;
+    void dispatchDidFinishResourceLoad(const WebCore::CachedResource&) override;
 
     void dispatchDidDispatchOnloadEvents() override;
     void dispatchDidReceiveServerRedirectForProvisionalLoad() override;
@@ -246,6 +253,10 @@ private:
     // QTFIXME: consider introducing some sort of flags for storing state
     bool m_isDisplayingErrorPage;
     bool m_shouldSuppressLoadStarted;
+    
+    // Helper methods for resource tracking
+    QString resourceTypeToString(WebCore::CachedResource::Type type) const;
+    QtResourceTimingInfo extractTimingInfo(const WebCore::NetworkLoadMetrics& metrics) const;
 };
 
 }

--- a/Source/WebKitLegacy/qt/WidgetApi/qwebpage.cpp
+++ b/Source/WebKitLegacy/qt/WidgetApi/qwebpage.cpp
@@ -3440,6 +3440,31 @@ bool QWebPage::recentlyAudible() const
 */
 
 /*!
+    \fn void QWebPage::resourceLoadStarted(const QUrl& url, const QtResourceRequestInfo& requestInfo, bool fromCache)
+
+    This signal is emitted when a resource (image, stylesheet, script, etc.) begins loading.
+    \a url contains the URL of the resource being loaded.
+    \a requestInfo contains detailed information about the resource request including HTTP method,
+    headers, priority, and other request metadata.
+    \a fromCache indicates whether the resource is being loaded from memory cache.
+
+    \sa resourceLoadFinished(), QtResourceRequestInfo
+*/
+
+/*!
+    \fn void QWebPage::resourceLoadFinished(const QUrl& url, qint64 size, const QtResourceTimingInfo& timing, bool success)
+
+    This signal is emitted when a resource finishes loading (successfully or with error).
+    \a url contains the URL of the resource that finished loading.
+    \a size contains the actual size in bytes of the loaded resource.
+    \a timing contains detailed timing information about the resource load including
+    DNS lookup, connection, request/response times, and cache status.
+    \a success indicates whether the resource loaded successfully.
+
+    \sa resourceLoadStarted(), QtResourceTimingInfo
+*/
+
+/*!
     \fn void QWebPage::linkHovered(const QString &link, const QString &title, const QString &textContent)
 
     This signal is emitted when the mouse hovers over a link.

--- a/Source/WebKitLegacy/qt/WidgetApi/qwebpage.h
+++ b/Source/WebKitLegacy/qt/WidgetApi/qwebpage.h
@@ -23,6 +23,7 @@
 
 #include <QtWebKit/qwebkitglobal.h>
 #include <QtWebKit/qwebfullscreenrequest.h>
+#include <QtWebKit/qwebresourcetypes.h>
 #include <QtWebKit/qwebsettings.h>
 
 #include <QtCore/qobject.h>
@@ -66,6 +67,7 @@ namespace WebCore {
     class QNetworkReplyHandler;
     class FrameLoadRequest;
 }
+
 
 class QWEBKITWIDGETS_EXPORT QWebPage : public QObject {
     Q_OBJECT
@@ -431,6 +433,8 @@ Q_SIGNALS:
     void loadStarted();
     void loadProgress(int progress);
     void loadFinished(bool ok);
+    void resourceLoadStarted(const QUrl& url, const QtResourceRequestInfo& requestInfo, bool fromCache);
+    void resourceLoadFinished(const QUrl& url, qint64 size, const QtResourceTimingInfo& timing, bool success);
 
     void linkHovered(const QString &link, const QString &title, const QString &textContent);
     void statusBarMessage(const QString& text);


### PR DESCRIPTION
Adds `QWebPage::resourceLoadStarted()` and `QWebPage::resourceLoadFinished()` signals, in order to be able to track which assets are in flight at any given time. This provides a slightly different view than QNAM, as it also includes assets that hit webkit's in-memory cache.