### PR TITLE
Cache font family lookups

### DIFF
--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -257,6 +257,10 @@ private:
     UncheckedKeyHashSet<AtomString> m_knownFamilies;
 #endif
 
+#if PLATFORM(QT)
+    UncheckedKeyHashMap<AtomString, bool> m_fontFamilyCache;
+#endif
+
 #if PLATFORM(COCOA)
     FontDatabase m_databaseAllowingUserInstalledFonts { AllowUserInstalledFonts::Yes };
     FontDatabase m_databaseDisallowingUserInstalledFonts { AllowUserInstalledFonts::No };

--- a/Source/WebCore/platform/graphics/qt/FontCacheQt.cpp
+++ b/Source/WebCore/platform/graphics/qt/FontCacheQt.cpp
@@ -96,7 +96,11 @@ Ref<Font> FontCache::lastResortFallbackFont(const FontDescription& fontDescripti
 
 std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext&, OptionSet<FontLookupOptions>)
 {
-    if (!QFontDatabase::hasFamily(family.string()))
+    auto addResult = m_fontFamilyCache.ensure(family, [&family] {
+        return QFontDatabase::hasFamily(family.string());
+    });
+
+    if (!addResult.iterator->value)
         return nullptr;
     return std::make_unique<FontPlatformData>(fontDescription, family);
 }


### PR DESCRIPTION
This call to `QFontDatabase::hasFamily()` is fairly expensive. It does quite a bit of name normalization, making it difficult for us to cache `QFontDatabase::families()` directly.